### PR TITLE
fix: latest-stable cmd filter to align w list-all

### DIFF
--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -17,4 +17,5 @@ fi
 # use GitHub releases latest API and follow redirect to resolve final version
 curl "${curl_opts[@]}" "$GH_REPO/releases/latest" |
 	sed -n -e "s|^location: $GH_REPO/releases/tag/||p" |
-	sed -n -e "s|\r||p"
+	sed -n -e "s|\r||p" |
+	sed 's|^v||'


### PR DESCRIPTION
Need to filter out versions prefixed with `v` so that it aligns with the list-all filter.